### PR TITLE
Fix production deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:1.9.1
 
-RUN apt-get update && apt-get install -y curl bzip2
+RUN apt-get update && apt-get install -y curl bzip2 git
 
 ##### INSTALLING NODE ######
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
@@ -24,10 +24,11 @@ RUN npm install -g grunt-cli bower
 
 COPY . /usr/src/app
 RUN npm install
+
 RUN bower --allow-root install
 
 RUN cd /usr/share/nginx/ \
     && rm -rf html/ \
     && ln -s /usr/src/app/bin/ html
 
-RUN grunt compile
+RUN grunt build_prod

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -648,6 +648,13 @@ module.exports = function(grunt) {
         'karma:continuous'
     ]);
 
+    grunt.registerTask('build_prod', [
+        'clean:all', 'html2js', 'jshint', 'coffeelint', 'coffee', 'less:build',
+        'concat:build_css', 'copy:build_app_assets', 'copy:build_vendor_assets',
+        'copy:build_appjs', 'copy:build_vendorjs', 'ngAnnotate:build', 'index:build',
+        'less:compile', 'copy:compile_assets', 'concat:compile_js', 'index:compile'
+    ]);
+
     // The 'compile' task gets your app ready for deployment by concatenating and minifying your code.
     // Note - compile builds off of the build dir (look at concat:compile_js), so run grunt build before grunt compile
     grunt.registerTask('compile', [


### PR DESCRIPTION
**Description**:

There was a problem with `grunt compile` - http://stackoverflow.com/questions/30624489/how-to-properly-deploy-angular-application-based-on-ngboilerplate-and-using-ngi. This fix solve this issue.

Because karma tests should not be run during production deployment (we don't want to install Firefox in docker container), I created new grunt task `build_prod` which contains all tasks from `build` and `compile` except `'karmaconfig', 'karma:continuous'`
