### PR TITLE
Added docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+web:
+  image: spistresci/manual-merge
+  ports:
+    - "80"
+  environment:
+    - VIRTUAL_HOST=manual-merge.spistresci.pl
+    - VIRTUAL_PORT=80


### PR DESCRIPTION
**Description**:

From now, you can just use `docker-compose up` to run [manual-merge.spistresci.pl](manual-merge.spistresci.pl) on production.

Note: nginx reverse proxy has to be deployed:
http://devblog.spistresci.pl/docker-osobne-subdomeny-dla-r%C3%B3%C5%BCnych-kontener%C3%B3w-na-jednym-serwerze/
